### PR TITLE
feat: support android builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,9 +12,10 @@ fn main() {
         // Include fake wasm-sysroot headers to pass compilation
         cc.include("wasm-sysroot");
         cc.archiver("llvm-ar");
-    } else if env::var("CARGO_CFG_TARGET_OS").unwrap() =="android" {
+    } else if env::var("CARGO_CFG_TARGET_OS").unwrap() == "android" {
         // this assumes that cargo-ndk is used initiate the build
-        let sysroot_path = env::var("CARGO_NDK_SYSROOT_PATH").expect("CARGO_NDK_SYSROOT_PATH is not set");
+        let sysroot_path =
+            env::var("CARGO_NDK_SYSROOT_PATH").expect("CARGO_NDK_SYSROOT_PATH is not set");
         // Construct the `CFLAGS` with `--sysroot` pointing to the NDK's sysroot path.
         let cflags = format!("--sysroot={}", sysroot_path);
         cc.flag(&cflags);

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,12 @@ fn main() {
         // Include fake wasm-sysroot headers to pass compilation
         cc.include("wasm-sysroot");
         cc.archiver("llvm-ar");
+    } else if env::var("CARGO_CFG_TARGET_OS").unwrap() =="android" {
+        // this assumes that cargo-ndk is used initiate the build
+        let sysroot_path = env::var("CARGO_NDK_SYSROOT_PATH").expect("CARGO_NDK_SYSROOT_PATH is not set");
+        // Construct the `CFLAGS` with `--sysroot` pointing to the NDK's sysroot path.
+        let cflags = format!("--sysroot={}", sysroot_path);
+        cc.flag(&cflags);
     }
     if !cfg!(debug_assertions) {
         cc.opt_level(2);


### PR DESCRIPTION
When building for android, set the sysroot based on the env variable set by `cargo-ndk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for building on Android.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->