### PR TITLE
feat: Windows support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,10 +26,10 @@ fn main() {
 
     let mut cc = cc::Build::new();
     cc.file("src/x11_hash.c");
-    cc.compiler("clang");
     cc.include("src");
-    cc.flag("-Wno-unused-but-set-variable");
+    // Only set clang for wasm, otherwise let cc auto-detect
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "wasm32" {
+        cc.compiler("clang");
         // Include fake wasm-sysroot headers to pass compilation
         cc.include("wasm-sysroot");
         cc.archiver("llvm-ar");

--- a/src/x11/sph_types.h
+++ b/src/x11/sph_types.h
@@ -49,7 +49,6 @@
 
 #include <limits.h>
 #include <string.h>
-#include <unistd.h>
 
 /*
  * All our I/O functions are defined over octet streams. We do not know


### PR DESCRIPTION
Just few changes to make windows builds possible. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined WebAssembly build configuration by explicitly selecting clang only for wasm targets while enabling automatic compiler detection for other supported platforms.
  * Removed unused compiler flags to improve build process cleanliness.
  * Reorganized platform-specific dependencies and settings to apply WebAssembly-specific customizations only when necessary, reducing unnecessary build configuration overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->