### PR TITLE
chore: drop unused `bindgen` code/dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ hex = "0.4.3"
 
 [build-dependencies]
 cc = "1.0.77"
-bindgen = ">= 0.57.0, <= 0.65.1"
 
 [lib]
 name = "rs_x11_hash"

--- a/build.rs
+++ b/build.rs
@@ -1,29 +1,8 @@
-extern crate bindgen;
 extern crate cc;
 
 use std::env;
-use std::path::PathBuf;
 
 fn main() {
-    // bindgen::Builder::default()
-    //     .header("src/x11/aes_helper.h")
-    //     .header("src/x11/Blake.h")
-    //     .header("src/x11/Bmw.h")
-    //     .header("src/x11/CubeHash.h")
-    //     .header("src/x11/Echo.h")
-    //     .header("src/x11/Groestl.h")
-    //     .header("src/x11/Jh.h")
-    //     .header("src/x11/Keccak.h")
-    //     .header("src/x11/Luffa.h")
-    //     .header("src/x11/Shavite.h")
-    //     .header("src/x11/Simd.h")
-    //     .header("src/x11/Skein.h")
-    //     .header("src/x11/sph_types.h")
-    //     .generate()
-    //     .expect("Error bindings generation")
-    //     .write_to_file(PathBuf::from(env::var("OUT_DIR").unwrap()).join("src.rs"))
-    //     .expect("Couldn't write bindings!");
-
     let mut cc = cc::Build::new();
     cc.file("src/x11_hash.c");
     cc.compiler("clang");


### PR DESCRIPTION
It's not used/needed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an external build dependency and refactored build configuration for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->