### PR TITLE
ci: add Android build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,19 @@ jobs:
       - run: cargo build --verbose
       - run: cargo build --release --verbose
       - run: cargo test --verbose
+
+  android:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [aarch64-linux-android, armv7-linux-androideabi]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+      - name: Build for Android
+        run: cargo ndk -t ${{ matrix.target }} build


### PR DESCRIPTION
Adds an Android build step to ci.yml. 

- Based on #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Android build testing to the continuous integration pipeline for improved quality assurance across multiple Android targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->